### PR TITLE
Whitelist weimaqi.net in WeChat

### DIFF
--- a/rules/com.tencent.mm.json
+++ b/rules/com.tencent.mm.json
@@ -14,7 +14,7 @@
       "tag": "QRScanner",
       "url-source": "intent://extra/rawUrl/url",
       "url-filter": {
-        "ignore": ".*qq\\.com/.*",
+        "ignore": ".*(qq\\.com|weimaqi\\.net)/.*",
         "force": ""
       }
     }


### PR DESCRIPTION
weimaqi.net is a QR code service provider which integrates WeChat Pay. It's a bit annoying to choose everytime. Thus I propose this PR if such kind of PR is welcomed.